### PR TITLE
Retain backward compatibility

### DIFF
--- a/pytak/classes.py
+++ b/pytak/classes.py
@@ -224,7 +224,6 @@ class CLITool:
     def __init__(
         self,
         config: ConfigParser,
-        full_config: ConfigParser,
         tx_queue: Union[asyncio.Queue, mp.Queue, None] = None,
         rx_queue: Union[asyncio.Queue, mp.Queue, None] = None,
     ) -> None:
@@ -233,7 +232,6 @@ class CLITool:
         self.running_tasks: Set = set()
         self._config = config
         self.queues = {}
-        self.full_config = full_config
         self.tx_queue: Union[asyncio.Queue, mp.Queue] = tx_queue or asyncio.Queue()
         self.rx_queue: Union[asyncio.Queue, mp.Queue] = rx_queue or asyncio.Queue()
 

--- a/pytak/client_functions.py
+++ b/pytak/client_functions.py
@@ -291,7 +291,7 @@ async def main(app_name: str, config: SectionProxy, full_config: ConfigParser) -
         A full dict of configuration parameters & values.
     """
     app = importlib.__import__(app_name)
-    clitool: pytak.CLITool = pytak.CLITool(config, full_config)
+    clitool: pytak.CLITool = pytak.CLITool(config)
     create_tasks = getattr(app, "create_tasks")
     await clitool.create_workers(config)
     if config.get("IMPORT_OTHER_CONFIGS", pytak.DEFAULT_IMPORT_OTHER_CONFIGS):


### PR DESCRIPTION
The full config is not necessary for the CLITool class.
This could potentially break any tool previously created using more than one ctor argument.
I suggest to remove this new initialization parameter.

One can still create multiple connections with more subsections having their own config passed using the create_workers method.