### PR TITLE
adding ability to send local_addr tuple to connect() call

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build-artifact:
-    runs-on: debian-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/python-publish_to_pypi.yml
+++ b/.github/workflows/python-publish_to_pypi.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   deploy:
 
-    runs-on: debian-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-test_and_lint.yml
+++ b/.github/workflows/python-test_and_lint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: debian-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-PyTAK 5.7.0b2
+PyTAK 5.7.0b3
 -------------
 Updates for AirTAK.
 - Proto updates

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
+# Makefile for PyTAK
 #
-# Copyright 2023 Greg Albrecht <gba@snstac.com>
+# Copyright 2023 Sensors & Signals LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,10 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author:: Greg Albrecht <gba@snstac.com>
-# Copyright:: Copyright 2023 Greg Albrecht
-# License:: Apache License, Version 2.0
 #
 
 this_app = pytak
@@ -39,6 +36,8 @@ uninstall:
 	python3 -m pip uninstall -y $(this_app)
 
 reinstall: uninstall install
+
+dist: build
 
 build:
 	python3 -m build

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,33 +6,33 @@ project = "PyTAK"
 copyright = "2023 Sensors & Signals LLC"
 author = "Greg Albrecht"
 
-release = '0.1.1'
-version = '0.1.1'
+release = "0.1.1"
+version = "0.1.1"
 
 # -- General configuration
 
-master_doc = 'index'
+master_doc = "index"
 
 extensions = [
-    'sphinx.ext.duration',
-    'sphinx.ext.doctest',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.coverage',
+    "sphinx.ext.duration",
+    "sphinx.ext.doctest",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.coverage",
 ]
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3/', None),
-    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
+    "python": ("https://docs.python.org/3/", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
 }
-intersphinx_disabled_domains = ['std']
+intersphinx_disabled_domains = ["std"]
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # -- Options for HTML output
 
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # -- Options for EPUB output
-epub_show_urls = 'footnote'
+epub_show_urls = "footnote"

--- a/pytak/__init__.py
+++ b/pytak/__init__.py
@@ -19,7 +19,7 @@
 :source: <https://github.com/snstac/pytak>
 """
 
-__version__ = "5.7.0b3"
+__version__ = "5.7.0-beta1"
 
 
 from .constants import (  # NOQA

--- a/pytak/__init__.py
+++ b/pytak/__init__.py
@@ -19,7 +19,7 @@
 :source: <https://github.com/snstac/pytak>
 """
 
-__version__ = "6.0.0b1"
+__version__ = "5.7.0b3"
 
 
 from .constants import (  # NOQA

--- a/pytak/asyncio_dgram/aio.py
+++ b/pytak/asyncio_dgram/aio.py
@@ -295,7 +295,7 @@ async def from_socket(sock):
     drained = asyncio.Event()
 
     supported_families = tuple((socket.AF_INET, socket.AF_INET6))
-    if not sys.platform == 'win32':
+    if not sys.platform == "win32":
         supported_families += (socket.AF_UNIX,)
 
     if sock.family not in supported_families:

--- a/pytak/asyncio_dgram/aio.py
+++ b/pytak/asyncio_dgram/aio.py
@@ -243,7 +243,7 @@ async def bind(addr):
     return DatagramServer(transport, recvq, excq, drained)
 
 
-async def connect(addr):
+async def connect(addr, local_addr=None):
     """
     Connect a socket to a remote address for datagrams.  The socket will be
     either AF_INET, AF_INET6 or AF_UNIX depending upon the type of host
@@ -271,6 +271,7 @@ async def connect(addr):
         lambda: Protocol(recvq, excq, drained),
         remote_addr=addr,
         family=family,
+        local_addr=local_addr,
     )
 
     return DatagramClient(transport, recvq, excq, drained)

--- a/pytak/classes.py
+++ b/pytak/classes.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Author:: Greg Albrecht <gba@snstac.com>
-#
 
 """PyTAK Class Definitions."""
 
@@ -74,16 +72,20 @@ class Worker:  # pylint: disable=too-few-public-methods
         tak_proto_version = config.getint("TAK_PROTO", pytak.DEFAULT_TAK_PROTO)
 
         if tak_proto_version > 0 and importlib.util.find_spec("takproto") is None:
-            self._logger.error("Failed to use takproto for parsing CoT serialized with protobuf.\n Try: pip install pytak[with_takproto]")
+            self._logger.error(
+                "Failed to use takproto for parsing CoT serialized with protobuf.\n Try: pip install pytak[with_takproto]"
+            )
 
-        self.use_protobuf = tak_proto_version > 0 and importlib.util.find_spec("takproto")
+        self.use_protobuf = tak_proto_version > 0 and importlib.util.find_spec(
+            "takproto"
+        )
         self._parse_proto = None
         self._xml2proto = None
-        
+
         if self.use_protobuf:
             self._parse_proto = lambda cot: takproto.parse_proto(cot)
             self._xml2proto = lambda cot: takproto.xml2proto(cot)
-        
+
     async def fts_compat(self) -> None:
         """Apply FreeTAKServer (FTS) compatibility.
 
@@ -153,7 +155,7 @@ class TXWorker(Worker):  # pylint: disable=too-few-public-methods
         if self.use_protobuf:
             host, _ = pytak.parse_url(self.config.get("COT_URL"))
             is_multicast: bool = False
-            
+
             try:
                 is_multicast = ipaddress.ip_address(host).is_multicast
             except ValueError:
@@ -197,15 +199,15 @@ class RXWorker(Worker):  # pylint: disable=too-few-public-methods
 
     async def readcot(self):
         try:
-            if hasattr(self.reader, 'readuntil'):
+            if hasattr(self.reader, "readuntil"):
                 cot = await self.reader.readuntil("</event>".encode("UTF-8"))
-            elif hasattr(self.reader, 'recv'):
+            elif hasattr(self.reader, "recv"):
                 cot, src = await self.reader.recv()
 
             if self.use_protobuf and self._parse_proto:
                 tak_v1 = self._parse_proto(cot)
                 if tak_v1 != -1:
-                    cot = tak_v1#.SerializeToString()
+                    cot = tak_v1  # .SerializeToString()
             return cot
         except asyncio.exceptions.IncompleteReadError:
             return None

--- a/pytak/client_functions.py
+++ b/pytak/client_functions.py
@@ -252,7 +252,7 @@ async def protocol_factory(  # NOQA pylint: disable=too-many-locals,too-many-bra
             ) from exc
     elif "udp" in scheme:
         iface = config.get("PYTAK_MULTICAST_IFACE")
-        local_addr = config.get("PYTAK_MULTICAST_LOCAL_ADDR")
+        local_addr = (config.get("PYTAK_MULTICAST_LOCAL_ADDR"), 0,) 
         reader, writer = await pytak.create_udp_client(cot_url, iface, local_addr)
     elif "http" in scheme:
         raise Exception("TeamConnect / Sit(x) Support comming soon.")

--- a/pytak/commands.py
+++ b/pytak/commands.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Author:: Greg Albrecht <gba@snstac.com>
-#
 
 """PyTAK Command Line."""
 

--- a/pytak/constants.py
+++ b/pytak/constants.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Author:: Greg Albrecht <gba@snstac.com>
-#
 
 """PyTAK Constants."""
 
@@ -71,7 +69,7 @@ DEFAULT_TLS_PARAMS_OPT: list = [
     "PYTAK_TLS_CLIENT_CIPHERS",
     "PYTAK_TLS_DONT_CHECK_HOSTNAME",
     "PYTAK_TLS_DONT_VERIFY",
-    "PYTAK_TLS_CLIENT_PASSWORD", # used for encrypted PEM such as P12
+    "PYTAK_TLS_CLIENT_PASSWORD",  # used for encrypted PEM such as P12
 ]
 
 DEFAULT_IMPORT_OTHER_CONFIGS: bool = False
@@ -85,7 +83,7 @@ DEFAULT_COT_VAL: str = "9999999.0"
 DEFAULT_MIN_ASYNC_SLEEP: float = 0.1
 
 # TAK Protocol to use for CoT output, one of: 0 (XML, default), 2 (Mesh), 2 (Stream).
-DEFAULT_TAK_PROTO = 0 
+DEFAULT_TAK_PROTO = 0
 
 # Python <3.8 has no way of including XML Declaration in ET.tostring():
 DEFAULT_XML_DECLARATION: bytes = (

--- a/pytak/crypto_functions.py
+++ b/pytak/crypto_functions.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Author:: Greg Albrecht <gba@snstac.com>
-#
 
 """PyTAK Crypto (as in cryptography) Functions."""
 
@@ -43,7 +41,7 @@ except ImportError:
 
 
 __author__ = "Greg Albrecht <gba@snstac.com>"
-__copyright__ = "Copyright 2023 Greg Albrecht"
+__copyright__ = "Copyright 2023 Sensors & Signals LLC"
 __license__ = "Apache License, Version 2.0"
 
 

--- a/pytak/functions.py
+++ b/pytak/functions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright 2023 Greg Albrecht <gba@snstac.com>
+# Copyright 2023 Sensors & Signals LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author:: Greg Albrecht <gba@snstac.com>
 #
 
 """PyTAK Functions."""
@@ -32,7 +30,7 @@ from urllib.parse import ParseResult, urlparse
 import pytak  # pylint: disable=cyclic-import
 
 __author__ = "Greg Albrecht <gba@snstac.com>"
-__copyright__ = "Copyright 2023 Greg Albrecht"
+__copyright__ = "Copyright 2023 Sensors & Signals LLC"
 __license__ = "Apache License, Version 2.0"
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,9 +33,7 @@ license = Apache 2.0
 license_files = LICENSE
 classifiers =
   License :: OSI Approved :: Apache Software License
-
   Intended Audience :: Developers
-
   Programming Language :: Python
   Programming Language :: Python :: 3
   Programming Language :: Python :: 3 :: Only
@@ -45,9 +43,7 @@ classifiers =
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
-
   Development Status :: 5 - Production/Stable
-
   Operating System :: POSIX
   Operating System :: MacOS :: MacOS X
   Operating System :: Microsoft :: Windows
@@ -64,7 +60,6 @@ keywords =
 
 [options]
 python_requires = >=3.6, <4
-# include_package_data = True
 
 
 [options.extras_require]
@@ -77,65 +72,3 @@ test =
   flake8
   black
   cryptography
-
-
-# [pep8]
-# max-line-length=88
-
-
-# [easy_install]
-# zip_ok = false
-
-
-# [flake8]
-# # ignore = N801,N802,N803,E203,E226,E305,W504,E252,E301,E302,E704,W503,W504,F811
-# max-line-length = 88
-
-# [aliases]
-# test=pytest
-
-# [isort]
-# line_length=88
-# include_trailing_comma=True
-# multi_line_output=3
-# force_grid_wrap=0
-# combine_as_imports=True
-
-# known_third_party=pytest
-# known_first_party=pytak
-
-# [report]
-# exclude_lines =
-#     @abc.abstractmethod
-#     @abstractmethod
-
-# [tool:pytest]
-# addopts = --cov=pytak -v -rxXs
-# filterwarnings = error
-# junit_suite_name = pytak_test_suite
-# junit_family = xunit2
-# norecursedirs = dist docs build .tox .eggs
-# minversion = 3.8.2
-# testpaths = tests/
-# asyncio_mode = strict
-
-# [coverage:run]
-# branch = True
-# source = pytak
-# omit = site-packages
-
-# [mypy]
-# follow_imports = silent
-# strict_optional = True
-# warn_redundant_casts = True
-
-# # uncomment next lines
-# # to enable strict mypy mode
-# #
-# check_untyped_defs = True
-# disallow_any_generics = True
-# disallow_untyped_defs = True
-# warn_unused_ignores = True
-
-# [mypy-pytest]
-# ignore_missing_imports = true


### PR DESCRIPTION
Hey @pcmarmotte I realized I met you halfway on this multicast bug. In my case I'm trying to bring up a machine w/ no default route and an unknown startup IP, and an interface IP that may change, so I'm passing in local_addr. I don't know if that's easier or harder than using the interface name, or if Windows is partial to one method or the other. I don't care which method we use, or we can use both, but I'm putting this PR up to show you where I got.