### PR TITLE
Allow asyncio to configure UDP broadcast.

### DIFF
--- a/pytak/asyncio_dgram/aio.py
+++ b/pytak/asyncio_dgram/aio.py
@@ -243,7 +243,7 @@ async def bind(addr):
     return DatagramServer(transport, recvq, excq, drained)
 
 
-async def connect(addr, local_addr=None):
+async def connect(addr, local_addr=None, allow_broadcast=None):
     """
     Connect a socket to a remote address for datagrams.  The socket will be
     either AF_INET, AF_INET6 or AF_UNIX depending upon the type of host
@@ -272,6 +272,7 @@ async def connect(addr, local_addr=None):
         remote_addr=addr,
         family=family,
         local_addr=local_addr,
+        allow_broadcast=allow_broadcast,
     )
 
     return DatagramClient(transport, recvq, excq, drained)

--- a/pytak/client_functions.py
+++ b/pytak/client_functions.py
@@ -93,13 +93,11 @@ async def create_udp_client(
         bindall = True if sys.platform == "win32" else False
         rsock.bind(("" if bindall else host, port))
         reader = await from_socket(rsock)
-    writer: DatagramClient = await dgconnect((host, port), local_addr=local_addr)
+    writer: DatagramClient = await dgconnect(
+        (host, port), local_addr=local_addr, allow_broadcast=is_broadcast)
 
-    if is_broadcast:
-        writer.socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-        # writer.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        if reader:
-            reader.socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    if is_broadcast and reader:
+        reader.socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
 
     if reader and (is_broadcast or is_multicast):
         reader.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)


### PR DESCRIPTION
This line appears to error when asyncio tries to bind because we have not yet specified that we are using a UDP broadcast url: https://github.com/snstac/pytak/blob/main/pytak/asyncio_dgram/aio.py#L270

Passing the broadcast argument appears to enable broadcast without breaking other UDP use-cases, but I am not certain what suite of tests to run to verify full robustness.

Please let me know if I am missing anything.