### PR TITLE
apply multicast membership to specified interface

### DIFF
--- a/pytak/client_functions.py
+++ b/pytak/client_functions.py
@@ -125,7 +125,7 @@ async def create_udp_client(
 
     # Create Multicast Reader
     if is_multicast:
-        ip = socket.INADDR_ANY if local_addr == None else int(ipaddress.IPv4Address(local_addr[0]))
+        ip = socket.INADDR_ANY if local_addr[0] is None else int(ipaddress.IPv4Address(local_addr[0]))
         group = int(ipaddress.IPv4Address(host))
         mreq = struct.pack("!LL", group, ip)
 

--- a/pytak/client_functions.py
+++ b/pytak/client_functions.py
@@ -125,8 +125,9 @@ async def create_udp_client(
 
     # Create Multicast Reader
     if is_multicast:
-        group = socket.inet_aton(host)
-        mreq = struct.pack("4sL", group, socket.INADDR_ANY)
+        ip = socket.INADDR_ANY if local_addr == None else int(ipaddress.IPv4Address(local_addr[0]))
+        group = int(ipaddress.IPv4Address(host))
+        mreq = struct.pack("!LL", group, ip)
 
         reader.socket.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
         reader.socket.setsockopt(

--- a/pytak/constants.py
+++ b/pytak/constants.py
@@ -47,7 +47,6 @@ DEFAULT_HOST_ID: str = f"pytak@{platform.node()}"
 DEFAULT_COT_PORT: str = "8087"
 DEFAULT_ATAK_PORT: str = "4242"
 DEFAULT_BROADCAST_PORT: str = "6969"
-DEFAULT_TAK_PROTO: str = "1"
 
 DEFAULT_BACKOFF: str = "120"
 DEFAULT_SLEEP: str = "5"
@@ -82,8 +81,8 @@ DEFAULT_COT_VAL: str = "9999999.0"
 # issue. See: https://github.com/snstac/pytak/pull/22
 DEFAULT_MIN_ASYNC_SLEEP: float = 0.1
 
-# TAK Protocol to use for CoT output, one of: 0 (XML, default), 2 (Mesh), 2 (Stream).
-DEFAULT_TAK_PROTO: str = "0"
+# TAK Protocol to use for CoT output, one of: 0 (XML, default), 1 (Mesh/Stream).
+DEFAULT_TAK_PROTO: str = "1"
 
 # Python <3.8 has no way of including XML Declaration in ET.tostring():
 DEFAULT_XML_DECLARATION: bytes = (


### PR DESCRIPTION
As a user I want to specify the network adapter on which the multicast reader listens.

This PR applies the `PYTAK_MULTICAST_LOCAL_ADDR` option to a multicast reader's socket.
Since this option works for both reader and writer, the `PYTAK_MULTICAST_IFACE` may not be necessary.