### PR TITLE
Resolve issues with tests

### DIFF
--- a/tests/test_client_functions.py
+++ b/tests/test_client_functions.py
@@ -145,8 +145,9 @@ async def test_protocol_factory_bad_url():
     """Test calling `pytak.protocol_factory()` with a bad URL."""
     test_url1: str = "udp:localhost"
     config: dict = {"COT_URL": test_url1}
-    with pytest.raises(Exception):
-        await pytak.protocol_factory(config)
+    with pytest.warns(SyntaxWarning, match="Invalid COT_URL"):
+        with pytest.raises(Exception):
+            await pytak.protocol_factory(config)
 
 
 @pytest.mark.asyncio

--- a/tests/test_pref_packages.py
+++ b/tests/test_pref_packages.py
@@ -28,18 +28,19 @@ __author__ = "Greg Albrecht <gba@snstac.com>"
 __copyright__ = "Copyright Sensors & Signals LLC https://www.snstac.com"
 __license__ = "Apache License, Version 2.0"
 
+__folder__ = os.path.dirname(__file__)
 
 def test_load_preferences() -> None:
     """Test loading a preferences file."""
-    test_pref: str = "tests/data/test_pref.pref"
-    prefs: dict = pytak.functions.load_preferences(test_pref, "tests/data")
+    test_pref: str = __folder__ + "/data/test_pref.pref"
+    prefs: dict = pytak.functions.load_preferences(test_pref, __folder__ + "/data")
     assert all(prefs)
 
 
 def test_load_connectString2url() -> None:
     """Test converting a TAK connectString to a URL"""
-    test_pref: str = "tests/data/test_pref.pref"
-    prefs: dict = pytak.functions.load_preferences(test_pref, "tests/data")
+    test_pref: str = __folder__ + "/data/test_pref.pref"
+    prefs: dict = pytak.functions.load_preferences(test_pref, __folder__ + "/data")
     connect_string: str = prefs.get("connect_string")
     url: str = pytak.functions.connectString2url(connect_string)
     assert url == "ssl://takserver.example.com:8089"
@@ -47,15 +48,15 @@ def test_load_connectString2url() -> None:
 
 def test_load_cert() -> None:
     cert: list = pytak.crypto_functions.load_cert(
-        "tests/data/test_user_cert.p12", "atakatak"
+        __folder__ + "/data/test_user_cert.p12", "atakatak"
     )
     assert len(cert) == 3
 
 
 def test_load_convert_cert():
     """Test converting P12 certs to a PEM certs."""
-    test_pref: str = "tests/data/test_pref.pref"
-    prefs: dict = pytak.functions.load_preferences(test_pref, "tests/data")
+    test_pref: str = __folder__ + "/data/test_pref.pref"
+    prefs: dict = pytak.functions.load_preferences(test_pref, __folder__ + "/data")
 
     client_password: str = prefs.get("client_password")
     assert client_password
@@ -76,23 +77,23 @@ def test_load_convert_cert():
     assert os.path.exists(cert_pem_path)
     assert os.path.exists(ca_pem_path)
 
-    with open("tests/data/test_pk.pem", "rb+") as tpk_fd:
+    with open(__folder__ + "/data/test_pk.pem", "rb+") as tpk_fd:
         test_pk = tpk_fd.read()
         with open(pk_pem_path, "rb+") as pk_fd:
             assert pk_fd.read() == test_pk
 
-    with open("tests/data/test_user_cert.pem", "rb+") as tc_fd:
+    with open(__folder__ + "/data/test_user_cert.pem", "rb+") as tc_fd:
         test_cert = tc_fd.read()
         with open(cert_pem_path, "rb+") as ck_fd:
             assert ck_fd.read() == test_cert
 
-    with open("tests/data/test_ca_cert.pem", "rb+") as tc_fd:
+    with open(__folder__ + "/data/test_ca_cert.pem", "rb+") as tc_fd:
         test_cert = tc_fd.read()
         with open(ca_pem_path, "rb+") as ck_fd:
             assert ck_fd.read() == test_cert
 
 
 def test_read_read_pref_package():
-    pref_package = "tests/data/test_pref_package.zip"
+    pref_package = __folder__ + "/data/test_pref_package.zip"
     prefs = pytak.client_functions.read_pref_package(pref_package)
     assert all(prefs)


### PR DESCRIPTION
OS: Ubuntu 22.04
Python version: 3.7.6 (fresh Anaconda environment: `conda create --name pytak python=3.7 -y; conda activate pytak`)

I just checked out the repo and ran the automated tests. The procedure for installing from source did not include any documentation for how to run the tests, but inferring what the procedure is wasn't that difficult. From the root workspace folder, I installed the test dependencies with `python3 -m pip install -r requirements_test.txt` and then ran the pytest suite:

```bash
$ pytest tests
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.7.6, pytest-7.4.4, pluggy-0.13.1
rootdir: /home/joe/work/github/pytak
plugins: ament-xmllint-0.12.11, ament-flake8-0.12.11, ament-copyright-0.12.11, ament-lint-0.12.11, launch-testing-1.0.6, launch-testing-ros-0.19.7, ament-pep257-0.12.11, anyio-2.2.0, cov-4.1.0, asyncio-0.21.2
asyncio: mode=strict
collected 41 items                                                                                                                                                     

tests/test_classes.py ..........                                                                                                                                 [ 24%]
tests/test_client_functions.py ..............                                                                                                                    [ 58%]
tests/test_functions.py ...........                                                                                                                              [ 85%]
tests/test_pref_packages.py .....                                                                                                                                [ 97%]
tests/test_pytak.py .                                                                                                                                            [100%]

=========================================================================== warnings summary ===========================================================================
tests/test_client_functions.py::test_protocol_factory_bad_url
  Warning: Invalid COT_URL=udp:localhost

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================== 41 passed, 1 warning in 0.37s =====================================================================
```

Reading the content of the tests though, it seems that the warning shouldn't really be a warning.  The invalid URL is what is being tested, right?

With the new commit applied, I was able to run the suite of automated tests with no warnings or errors.

```bash
$ pytest tests
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.7.6, pytest-7.4.4, pluggy-0.13.1
rootdir: /home/joe/work/github/pytak
plugins: ament-xmllint-0.12.11, ament-flake8-0.12.11, ament-copyright-0.12.11, ament-lint-0.12.11, launch-testing-1.0.6, launch-testing-ros-0.19.7, ament-pep257-0.12.11, anyio-2.2.0, cov-4.1.0, asyncio-0.21.2
asyncio: mode=strict
collected 41 items                                                                                                                                                     

tests/test_classes.py ..........                                                                                                                                 [ 24%]
tests/test_client_functions.py ..............                                                                                                                    [ 58%]
tests/test_functions.py ...........                                                                                                                              [ 85%]
tests/test_pref_packages.py .....                                                                                                                                [ 97%]
tests/test_pytak.py .                                                                                                                                            [100%]

========================================================================== 41 passed in 0.18s ==========================================================================
```