### PR TITLE
add option for multicast_ttl value

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,6 +69,10 @@ PyTAK has the following built-in configuration parameters:
 
     For systems with multiple IP network interfaces, specifies which IP interface to use for the multicast group.
 
+* **`PYTAK_MULTICAST_TTL`**
+    * Default: `1`
+
+    For clients that are more than one hop away from the TAK broadcast network, specifies the time-to-live (TTL) of multicast packets. This is helpful when the client is hosted in a virtual machine or container with an overlay network.
 
 ## CoT Event Attributes
 

--- a/pytak/client_functions.py
+++ b/pytak/client_functions.py
@@ -108,7 +108,8 @@ async def protocol_factory(  # NOQA pylint: disable=too-many-locals,too-many-bra
             ),
             0,
         )
-        reader, writer = await pytak.create_udp_client(cot_url, local_addr)
+        multicast_ttl = config.get("PYTAK_MULTICAST_TTL", 1)
+        reader, writer = await pytak.create_udp_client(cot_url, local_addr, multicast_ttl)
 
     # LOG
     elif "log" in scheme:
@@ -130,7 +131,7 @@ async def protocol_factory(  # NOQA pylint: disable=too-many-locals,too-many-bra
 
 
 async def create_udp_client(
-    url: ParseResult, local_addr=None
+    url: ParseResult, local_addr=None, multicast_ttl=1
 ) -> Tuple[Union[DatagramClient, None], DatagramClient]:
     """Create an AsyncIO UDP network client for Unicast, Broadcast & Multicast.
 
@@ -170,6 +171,11 @@ async def create_udp_client(
     if is_broadcast:
         writer.socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
 
+    if is_multicast:
+        writer.socket.setsockopt(
+            socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, struct.pack("b", multicast_ttl)
+        )
+
     if is_write_only:
         return reader, writer
 
@@ -207,11 +213,7 @@ async def create_udp_client(
         )
         group = int(ipaddress.IPv4Address(host))
         mreq = struct.pack("!LL", group, ip)
-
         reader.socket.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
-        reader.socket.setsockopt(
-            socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, struct.pack("b", 1)
-        )
 
     return reader, writer
 


### PR DESCRIPTION
As a pytak client administrator I want to set the MULTICAST_TTL value to allow clients to reach the TAK broadcast domain. 

At times clients are deployed in virtual machines or containers on an overlay network where TTL=1 only gets to the host. Configuring a `PYTAK_MULTICAST_TTL` environment variable provides admins an additional option to ease the networking configuration burden for the deployment scenario.

Additionally, the socket option was no longer being set for the writer, just the reader (which is unnecessary). 