### PR TITLE
Added functionality to build more detailed COT messages 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,24 @@
+## PyTAK 7.1.0-beta
+
+- Removed `bytes` as a data type option for `lat`, `lon`, `ce`, `hae`, `le` in `gen_cot_xml(...) function`.
+  - Bytes was not building well in XML, preferred str, float, or int.
+- Modified `gen_cot(...)` function to reflect removal of `bytes` data type.
+- Added function `gen_cot_detailed_xml(...)` to facilitate building a COT with all attributes for the `event` element, and some `detail` elements.
+- Added function `gen_delete_cot_xml(uid)` that will delete any previous COT that matches the `uid` that needs to be deleted.
+  - Just provide the `uid` as argument.
+- Added function `is_valid_datetime()` to validate a datetime string that needs to match the following formats: `%Y-%m-%dT%H:%M:%S.%fZ` with millis or `%Y-%m-%dT%H:%M:%SZ` without millis.
+- Added constant: DEFAULT_COT_DELETE_TYPE: str = "t-x-d-d".
+- Added an Enum class for the `access` attribute for `event` element.
+  - Class is called: `MIL_STD_6090_ACCESS_VALUES`
+- Added two more example scripts:
+  - `cot_builder.py` -> to show the use of built-in functions that facilitate building a COT.
+  - `cot_deleter.py` -> to show how to delete a COT after sending it.
+
 ## PyTAK 7.1.0
 
 Happy Lunar New Year 2025 - Year of the Snake.
 
-- Fixes 
-
+- Fixes
 
 ## PyTAK 7.0.1
 
@@ -71,11 +86,13 @@ Happy Summer Solstice
 ## PyTAK 6.0.0
 
 - Moved & expanded documentation at https://pytak.readthedocs.io/
-- ``COT_URL`` now defaults to ``udp+wo://239.2.3.1:6969``, aka 'Mesh SA' in ATAK & WinTAK. This disables receiveing CoT by default. To enable receiving CoT, remove the ``+wo`` modifier. 
-* Fixes #31: 'protobuf support', "TAK Protocol, Version 1" is now the default output from PyTAK, *BUT* you must install the ``takproto`` python module seperately to ENABLE, otherwise reverts to CoT XML. PyTAK will automatically detect if the ``COT_URL`` is multicast or unicast, and use the appropriate protobuf format. See: https://github.com/snstac/takproto
-* Fixes #36: 'Network is unreachable', added ``PYTAK_MULTICAST_LOCAL_ADDR`` to allow setting bind port on network connections.
+- `COT_URL` now defaults to `udp+wo://239.2.3.1:6969`, aka 'Mesh SA' in ATAK & WinTAK. This disables receiveing CoT by default. To enable receiving CoT, remove the `+wo` modifier.
+
+* Fixes #31: 'protobuf support', "TAK Protocol, Version 1" is now the default output from PyTAK, _BUT_ you must install the `takproto` python module seperately to ENABLE, otherwise reverts to CoT XML. PyTAK will automatically detect if the `COT_URL` is multicast or unicast, and use the appropriate protobuf format. See: https://github.com/snstac/takproto
+* Fixes #36: 'Network is unreachable', added `PYTAK_MULTICAST_LOCAL_ADDR` to allow setting bind port on network connections.
 * Fixes #37: 'unknown compression', reverted to github builder ubuntu-20.04
-- Added support for reading PKCS#12 (.p12) files containing public-private key pairs. Set p12 file with ``PYTAK_TLS_CLIENT_CERT``, and keystore password with ``PYTAK_TLS_CLIENT_PASSWORD``.
+
+- Added support for reading PKCS#12 (.p12) files containing public-private key pairs. Set p12 file with `PYTAK_TLS_CLIENT_CERT`, and keystore password with `PYTAK_TLS_CLIENT_PASSWORD`.
 - Updates for AirTAK v1 support: https://www.snstac.com/blog/introducing-airtak-v1
 - Moved setup.py metadata to setup.cfg
 - Style, lint and layout cleanup of code.
@@ -87,49 +104,54 @@ Happy Summer Solstice
 
 Exported `read_pref_package()` from client_functions.
 
-PyTAK 5.6.0
------------
+## PyTAK 5.6.0
+
 New Features:
+
 - Made cryptography an install extras: You'll need this to use data packages! To install: `python3 -m pip install pytak[with_crypto]`
 - Added write-only socket option to UDP sockets. Add `+wo` to the URL schema, as in: `udp+wo://239.2.3.1:6969`.
 
 Bug Fixes:
+
 - Fixed bad parsing of env var '%' characters on config import.
 
-PyTAK 5.5.0
------------
+## PyTAK 5.5.0
+
 New Features:
+
 - Added multicast receive support.
 - Added pref package / data package .zip support.
 
 Other:
+
 - Code cleanup.
 - Documentation & README updates.
 - 2023 copyright updates.
 - Ramped up code coverage to at least 50% on most files.
 - Added example of takproto support.
 
-PyTAK 5.4.1
------------
+## PyTAK 5.4.1
+
 Fixes #24, const as bytes not str.
 
-PyTAK 5.4.0
------------
+## PyTAK 5.4.0
+
 Added CoT XML Declaration constant, should be included with all output XML CoT.
 
-PyTAK 5.3.1
------
+## PyTAK 5.3.1
+
 Readme cleanup.
 
 Changed behavior of while loops to sleep 0.1 instead of 0, which was causing
 high CPU. See https://github.com/snstac/pytak/pull/22 thanks @PeterQFR.
 
+## PyTAK 5.2.0
 
-PyTAK 5.2.0
------
 New Features:
+
 - Added support for both AsyncIO & Multiprocessing Queues in PyTAK Workers classes.
 - Added support for specifying TX & RX queue when instantiating PyTAK CLITool.
 
 Bug & Performance Fixes:
+
 - Added async sleeps to each TX & RX loops iteration to fix broken async regiment in PYTAK.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,21 @@ PyTAK is a Python Module for creating Team Awareness Kit ([TAK](https://tak.gov)
 - **Data Handling**: Manage TAK, Cursor on Target (CoT), and non-CoT data.
 - **Data Parsing and Serialization**: Parse and serialize TAK and CoT data.
 - **Network Communication**: Send and receive TAK and CoT data over a network.
+- **COT Building Support**: Build your COTs fast and easy by leveraging easy-to-use builder functions.
 
 ## Documentation
 
-See [PyTAK documentation](https://pytak.rtfd.io/) for instructions on getting 
+See [PyTAK documentation](https://pytak.rtfd.io/) for instructions on getting
 started with PyTAK, examples, configuration & troubleshooting options.
+
+## COT Building
+
+This library provides the following functions to help the user build COTs:
+
+- `gen_cot_xml(...)`: generates a minimum COT event in XML and returns it as `ET.Element` object. This object can be modified later by adding or editing its elements.
+- `gen_cot_detailed_xml(...)`: generates a more detailed COT event in XML with support for all attributes for the `event` element. Returns COT as `ET.Element` object. This object can be modified later by adding or editing its elements.
+- `gen_cot(...)`: a wrapper function around `gen_cot_xml(...)`. Returns COT as `bytes` and is ready to send to TAK server. This is the way to go if you are looking for easy and fast integration of your COTs, or you are not interested in modifying the COTs any further.
+- `gen_delete_cot_xml(uid_to_delete, ...)`: generates a COT that will delete a previous sent COT if it matches the `uid`. Returns COT as `bytes` and is ready to be sent to TAK without having to make any change to it.
 
 ## License & Copyright
 
@@ -30,6 +40,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-asyncio_dgram is Copyright (c) 2019 Justin Bronder and is licensed under the MIT 
+asyncio_dgram is Copyright (c) 2019 Justin Bronder and is licensed under the MIT
 License, see pytak/asyncio_dgram/LICENSE for details.
-

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,12 +1,11 @@
-
 ## Send TAK Data
 
-The following Python 3.7+ code example creates a TAK Client that generates ``takPong`` 
-CoT every 20 seconds, and sends them to a TAK Server at 
-``tcp://takserver.example.com:8087`` (plain / clear TCP).
+The following Python 3.7+ code example creates a TAK Client that generates `takPong`
+CoT every 20 seconds, and sends them to a TAK Server at
+`tcp://takserver.example.com:8087` (plain / clear TCP).
 
-To run this example as-is, save the following code-block out to a file named 
-``send.py`` and run the command ``python3 send.py``::
+To run this example as-is, save the following code-block out to a file named
+`send.py` and run the command `python3 send.py`::
 
 ```python
 {!examples/send.py!}
@@ -16,10 +15,28 @@ To run this example as-is, save the following code-block out to a file named
 
 TK TK TK
 
-To run this example as-is, save the following code-block out to a file named 
-``send_receive.py`` and run the command ``python3 send_receive.py``::
+To run this example as-is, save the following code-block out to a file named
+`send_receive.py` and run the command `python3 send_receive.py`::
 
 ```python
 {!examples/send_receive.py!}
 ```
 
+## Generate COTs using built-in helper functions
+
+This script shows some basic and advanced use cases on how you can build COTs using the available helper functions from the library.  
+To run this example as-is, save the following code-block out to a file named
+`cot_builder.py`, change the configuration to match your TAK server, and run the command `python3 cot_builder.py`::
+
+```python
+{!examples/cot_builder.py!}
+```
+
+## Generate a COT deleter message
+
+This script shows the capability to generate a COT that deletes a previously sent COT by matching the `uid`. To run this example as-is, save the following code-block out to a file named
+`cot_deleter.py`, change the configuration to match your TAK server, and run the command `python3 cot_deleter.py`::
+
+```python
+{!examples/cot_deleter.py!}
+```

--- a/examples/cot_builder.py
+++ b/examples/cot_builder.py
@@ -1,0 +1,203 @@
+#!/home/henri.berisha/anaconda3/envs/tak/bin/python3
+
+import asyncio
+import os
+import sys
+import xml.etree.ElementTree as ET
+from configparser import ConfigParser
+from typing import Optional, Tuple, Union
+
+import pytak
+
+
+# for TAK, time should have this format: "%Y-%m-%dT%H:%M:%S.%fZ"
+# does not matter if it has milliseconds, or no, also the digits for the milliseconds dont matter
+
+# If you are looking to push simple minimal CoT events, this is the way to go
+def generate_minimum_cot_event():
+    lat = "40.77538253016966"  # do not do bytes, preferred is float, or str
+    lon = "-73.97084063459074"  # do not do bytes, preferred is float, or str
+    hae = "10"
+    ce = pytak.DEFAULT_COT_VAL
+    le = pytak.DEFAULT_COT_VAL
+    uid = "Minimal CoT"
+    stale = 60  # 60 seconds until it stalls
+    cot_type = None  # This will cause it to default to "a-u-G". Choose your CoT type for the desired marker
+
+    # leveraging pytak's `gen_cot` function
+    # this is a wrapper function for: gen_cot_xml(...)
+    return pytak.gen_cot(lat=lat, lon=lon, ce=ce, hae=hae, le=le, uid=uid, stale=stale, cot_type=cot_type)  # <class 'bytes'>
+
+
+# This is the advanced way to send a more wholesome CoT with support for all attributes for the `event` element
+def generate_detailed_cot_event():
+    lat = "40.77538253016966"
+    lon = "-73.97084063459074"
+    hae = "10"
+    ce = pytak.DEFAULT_COT_VAL
+    le = pytak.DEFAULT_COT_VAL
+    uid = "Detailed CoT"
+    stale = 60
+    cot_type = None
+    cot_how = "h-i-h"
+    timestamp = None
+    access = pytak.MIL_STD_6090_ACCESS_VALUES.NATO_SECRET
+    caveat = "CUI"
+    releasableto = "GBR"
+    qos = "9-r-g"
+    opex = "o-Easy CoTs"
+    callsign = "MyDetailedCoT"
+    remarks = "TestRemark"
+    flow_tags_include = True
+    flow_tags_custom = None
+
+    # Might be better to call all args by name rather than position, this way may skip what are not needed.
+    # If calling by position, you need to provide them all
+    base_cot_event: Union[ET.Element, bytes, None] = pytak.gen_cot_detailed_xml(
+        lat, lon, hae, ce, le, uid, stale, cot_type, cot_how, timestamp, access, caveat, releasableto, qos, opex, callsign, remarks, flow_tags_include, flow_tags_custom
+    )
+
+    if isinstance(base_cot_event, ET.Element):
+        cot = b"\n".join([pytak.DEFAULT_XML_DECLARATION, ET.tostring(base_cot_event)])
+    
+    return cot  # <class 'bytes'>
+
+
+# This is based on the minimal CoT event, but showcasing how to add more attributes and subelements for the `detail` element
+def generate_minimum_cot_event_with_detail():
+    lat = "40.77538253016966"
+    lon = "-73.97084063459074"
+    ce = pytak.DEFAULT_COT_VAL
+    hae = "10"
+    le = pytak.DEFAULT_COT_VAL
+    uid = "MinimalCoT"
+    stale = 60
+    cot_type = None
+
+    # Might be better to call all args by name rather than position, this way may skip what are not needed.
+    # If calling by position you need to provide them all
+    base_cot_event: Union[ET.Element, bytes, None] = pytak.gen_cot_xml(lat, lon, ce, hae, le, uid, stale, cot_type)
+
+    # here modify the base event with whatever you need
+    tree = ET.ElementTree(base_cot_event)
+    event: ET.Element = tree.getroot()
+    detail: ET.Element = event.find("detail")
+
+    remark = ET.Element("remarks")
+    text: str = f"I added remarks to the minimal CoT event"
+    remark.text = text
+    detail.append(remark)
+
+    # similar you can append more subelements to the `detail element
+
+    # in the end dont append detail to event, it is already appended, you are just adding subelements to detail
+    if isinstance(base_cot_event, ET.Element):
+        cot = b"\n".join([pytak.DEFAULT_XML_DECLARATION, ET.tostring(event)])
+    
+    return cot  # <class 'bytes'>
+
+
+# This is based on the advanced COT event, but showcasing how to add more attributes and subelements for the `detail` element
+def generate_detailed_cot_event_with_more_details():
+    lat = "40.77538253016966"
+    lon = '-73.97084063459074'
+    hae = "10"
+    ce = pytak.DEFAULT_COT_VAL
+    le = pytak.DEFAULT_COT_VAL
+    uid = "Detail Edited"
+    stale = 60
+    cot_type = None
+    cot_how = "h-i-h"
+    timestamp = None
+    access = pytak.MIL_STD_6090_ACCESS_VALUES.NATO_SECRET
+    caveat = "CUI"
+    releasableto = "GBR"
+    qos = "9-r-g"
+    opex = "o-Easy CoTs"
+    callsign = "DetailedCoTwithTrack"
+    remarks = "TestRemark"
+    flow_tags_include = True
+    flow_tags_custom = None
+
+    # here callsign left out on purpose, so it can be edited later
+    # here arguments are given by name, hence we do not have to provide all of them, order does not matter either. 
+    # What is not provided will default to its preset value
+    base_cot_event: Union[ET.Element, bytes, None] = pytak.gen_cot_detailed_xml(
+        lat=lat, lon=lon, flow_tags_include=False, uid=uid
+    )
+
+    # here modify the base event with whatever you need
+    tree = ET.ElementTree(base_cot_event)
+    event: ET.Element = tree.getroot()
+    detail: ET.Element = event.find("detail")
+
+    # similarly, can add other subelements depending on the use case
+    # subelement `contact` with `callsign` as its attribute. This is being appended directly to `detail`
+    ET.SubElement(detail, "contact", {"callsign": callsign})
+
+    dummy_heading = 270  # deg
+    dummy_speed = 7.8  # m/s
+    track = ET.Element("track")
+
+    #  Append heading only if available
+    if 0.0 <= dummy_heading <= 359.99:
+        track.set("course", str(dummy_heading))
+    track.set("speed", str(dummy_speed))  # # COT Speed is meters/second
+    detail.append(track)
+
+    if isinstance(base_cot_event, ET.Element):
+        cot = b"\n".join([pytak.DEFAULT_XML_DECLARATION, ET.tostring(base_cot_event)])
+    
+    return cot  # <class 'bytes'>
+
+
+class MySerializer(pytak.QueueWorker):
+    """
+    Defines how you process or generate your Cursor-On-Target Events.
+    From there it adds the COT Events to a queue for TX to a COT_URL.
+    """
+
+    async def handle_data(self, data):
+        """
+        Handles pre-COT data and serializes to COT Events, then puts on queue.
+        """
+        event = data
+        print(event, type(event))
+        await self.put_queue(event)
+
+    async def run(self, number_of_iterations=-1):
+        """
+        Runs the loop for processing or generating pre-COT data.
+        """
+        while 1:
+            # data = generate_minimum_cot_event()
+            # data = generate_detailed_cot_event()
+            # data = generate_minimum_cot_event_with_detail()
+            data = generate_detailed_cot_event_with_more_details()
+            await self.handle_data(data)
+            await asyncio.sleep(5)  # sleep for 30 secs
+
+
+async def main():
+    """
+    The main definition of your program, sets config params and
+    adds your serializer to the asyncio task list.
+    """
+    # your TAK server config here
+    config = ConfigParser()
+    config["mycottool"] = {"COT_URL": "tcp://takserver.example.com:8087"}
+    config = config["mycottool"]
+
+    # Initializes worker queues and tasks.
+    clitool = pytak.CLITool(config)
+    await clitool.setup()
+
+    # Add your serializer to the asyncio task list.
+    clitool.add_tasks(set([MySerializer(clitool.tx_queue, config)]))
+
+    # Start all tasks.
+    await clitool.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/cot_deleter.py
+++ b/examples/cot_deleter.py
@@ -1,0 +1,79 @@
+import asyncio
+import os
+import sys
+import xml.etree.ElementTree as ET
+from configparser import ConfigParser
+from typing import Optional, Tuple, Union
+
+import pytak
+
+""" 
+The purpose of this example is to show how to send a CoT message that deletes a previous CoT
+Just provide the uid of the COT to be deleted
+Now you do not have to wait until the stale time has passed for the marker to be removed
+"""
+
+def generate_minimum_cot_event():
+    lat = "40.77538253016966"  # do not do bytes, preferred is float, or str
+    lon = "-73.97084063459074"  # do not do bytes, preferred is float, or str
+    hae = "10"
+    ce = pytak.DEFAULT_COT_VAL
+    le = pytak.DEFAULT_COT_VAL
+    uid = "Minimal CoT"
+    stale = 60  # 60 seconds until it stalls
+    cot_type = None  # This will cause it to default to "a-u-G". Choose your CoT type for the desired marker
+
+    # leveraging pytak's `gen_cot` function
+    return pytak.gen_cot(lat=lat, lon=lon, ce=ce, hae=hae, le=le, uid=uid, stale=stale, cot_type=cot_type)  # <class 'bytes'>
+
+
+class MySerializer(pytak.QueueWorker):
+    """
+    Defines how you process or generate your Cursor-On-Target Events.
+    From there it adds the COT Events to a queue for TX to a COT_URL.
+    """
+
+    async def handle_data(self, data):
+        """
+        Handles pre-COT data and serializes to COT Events, then puts on queue.
+        """
+        event = data
+        print(event, type(event), end="\n\n")
+        await self.put_queue(event)
+
+    async def run(self, number_of_iterations=-1):
+        """
+        Runs the loop for processing or generating pre-COT data.
+        """
+        while 1:
+            data = generate_minimum_cot_event()
+            await self.handle_data(data)
+            await asyncio.sleep(5)
+            data = pytak.gen_delete_cot_xml("Minimal CoT") # just provide the uid of cot to delete
+            await self.handle_data(data)
+            await asyncio.sleep(5)
+
+
+async def main():
+    """
+    The main definition of your program, sets config params and
+    adds your serializer to the asyncio task list.
+    """
+    # your TAK server config here
+    config = ConfigParser()
+    config["mycottool"] = {"COT_URL": "tcp://takserver.example.com:8087"}
+    config = config["mycottool"]
+
+    # Initializes worker queues and tasks.
+    clitool = pytak.CLITool(config)
+    await clitool.setup()
+
+    # Add your serializer to the asyncio task list.
+    clitool.add_tasks(set([MySerializer(clitool.tx_queue, config)]))
+
+    # Start all tasks.
+    await clitool.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/pytak/__init__.py
+++ b/src/pytak/__init__.py
@@ -44,6 +44,8 @@ from .constants import (  # NOQA
     DEFAULT_COT_QOS,
     DEFAULT_COT_OPEX,
     DEFAULT_COT_VAL,
+    DEFAULT_COT_DELETE_TYPE,
+    MIL_STD_6090_ACCESS_VALUES,
     DEFAULT_MAX_OUT_QUEUE,
     DEFAULT_MAX_IN_QUEUE,
 )
@@ -63,8 +65,11 @@ from .functions import (  # NOQA
     parse_url,
     hello_event,
     cot_time,
+    is_valid_datetime,
     gen_cot,
     gen_cot_xml,
+    gen_cot_detailed_xml,
+    gen_delete_cot_xml,
     cot2xml,
 )
 

--- a/src/pytak/constants.py
+++ b/src/pytak/constants.py
@@ -20,6 +20,7 @@
 import logging
 import os
 import platform
+from enum import Enum
 
 from typing import Optional
 
@@ -81,6 +82,7 @@ DEFAULT_IMPORT_OTHER_CONFIGS: str = "0"
 
 BOOLEAN_TRUTH: list = ["true", "yes", "y", "on", "1"]
 DEFAULT_COT_VAL: str = "9999999.0"
+DEFAULT_COT_DELETE_TYPE: str = "t-x-d-d"
 
 # TAK Protocol to use for CoT output, one of: 0 (XML, default), 1 (Mesh/Stream).
 # Doesn't always work with iTAK. Recommend sticking with 0 (XML).
@@ -100,6 +102,16 @@ DEFAULT_COT_CAVEAT: Optional[str] = os.getenv("COT_CAVEAT", "")
 DEFAULT_COT_RELTO: Optional[str] = os.getenv("COT_RELTO", "")
 DEFAULT_COT_QOS: Optional[str] = os.getenv("COT_QOS", "")
 DEFAULT_COT_OPEX: Optional[str] = os.getenv("COT_OPEX", "")
+
+class MIL_STD_6090_ACCESS_VALUES(Enum):
+    UNCLASSIFIED = "Unclassified"
+    NATO_UNCLASSIFIED = "NATO Unclassified"
+    NATO_RESTRICTED = "NATO Restricted"
+    CONFIDENTIAL = "Confidential"
+    NATO_CONFIDENTIAL = "NATO Confidential"
+    SECRET = "Secret"
+    NATO_SECRET = "NATO Secret"
+    UNDEFINED = "Undefined"
 
 DEFAULT_MAX_OUT_QUEUE = 100
 DEFAULT_MAX_IN_QUEUE = 500


### PR DESCRIPTION
In this commit i added the following:
- A constant for the CoT delete type
-  A constant enum class containing the values for the `access` event attribute
- A function to validate an input datetime that needs to match the TAK format
- A function to generate a detailed COT similar to the existing `gen_cot_xml`
- A function to generate a COT that deletes a previous COT by matching the `uid`
- Removed `bytes` type hint for those functions, bytes does not work well when trying to append to the XML
- Documented the parameters of the functions
- Changed  the log
- Added 2 scripts as examples to document and showcase the added capability
- Modified the `examples.md` to refect the new scripts