### PR TITLE
Added support for IPv6 addresses

### DIFF
--- a/src/pytak/client_functions.py
+++ b/src/pytak/client_functions.py
@@ -329,7 +329,7 @@ async def create_tls_client(
 
     try:
         reader, writer = await asyncio.open_connection(
-            host, port, ssl=ssl_ctx, server_hostname=expected_server_hostname
+            host.strip("[]"), port, ssl=ssl_ctx, server_hostname=expected_server_hostname
         )
     except ssl.SSLCertVerificationError as exc:
         raise SyntaxError(

--- a/src/pytak/functions.py
+++ b/src/pytak/functions.py
@@ -65,7 +65,7 @@ def parse_url(url: Union[str, ParseResult]) -> Tuple[str, int]:
     host: str = _url.netloc
 
     if ":" in _url.netloc:
-        host, port = _url.netloc.split(":")
+        host, port = _url.netloc.rsplit(":", 1)
     else:
         if "broadcast" in _url.scheme:
             port = pytak.DEFAULT_BROADCAST_PORT


### PR DESCRIPTION
While using IPv6, you have to use brackets (`[]`) to separate the IPv6 address from the port number - see below:
``` python
    config["mycottool"] = {
        "COT_URL": "tls://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:8089"
    }
```