### PR TITLE
fix: warn when WS TX sends raw XML to a TAK Protocol endpoint

### DIFF
--- a/src/pytak/classes.py
+++ b/src/pytak/classes.py
@@ -585,6 +585,23 @@ class WSTXWorker(Worker):
         super().__init__(queue, config)
         self._ws = ws
         self._session = session
+        self._warned_no_takproto = False
+
+    def _warn_no_takproto(self) -> None:
+        """Warn once when raw XML is sent to a TAK Protocol endpoint."""
+        if self._warned_no_takproto:
+            return
+        cot_url = str(self.config.get("COT_URL") or "")
+        if pytak.DEFAULT_WS_PATH not in cot_url:
+            return
+        self._warned_no_takproto = True
+        self._logger.warning(
+            "WS TX: The 'takproto' Python module is not installed, so raw CoT XML "
+            "is being sent to the TAK Protocol endpoint '%s'. TAK Server will "
+            "silently discard these events.\n"
+            "Try: python -m pip install pytak[with_takproto]",
+            cot_url,
+        )
 
     async def handle_data(self, data: bytes) -> None:
         if not data:
@@ -594,6 +611,8 @@ class WSTXWorker(Worker):
                 data = takproto.xml2proto(data, takproto.TAKProtoVer.STREAM)
             except Exception as exc:
                 self._logger.warning("WS TX: Protobuf encode failed, sending raw: %s", exc)
+        else:
+            self._warn_no_takproto()
         try:
             await self._ws.send_bytes(data)
         except Exception as exc:

--- a/tests/test_ws_workers.py
+++ b/tests/test_ws_workers.py
@@ -116,6 +116,43 @@ async def test_ws_tx_worker_falls_back_on_proto_error():
     mock_ws.send_bytes.assert_called_once_with(SAMPLE_COT)
 
 
+@pytest.mark.asyncio
+async def test_ws_tx_worker_warns_once_when_takproto_missing(caplog):
+    """WSTXWorker should warn that raw XML sent to a TAK Protocol endpoint is dropped."""
+    queue = asyncio.Queue()
+    mock_ws = mock.MagicMock()
+    mock_ws.send_bytes = AsyncMock()
+
+    cot_url = f"wss://takserver.example.com:8443{pytak.DEFAULT_WS_PATH}"
+    worker = WSTXWorker(queue, {"COT_URL": cot_url}, mock_ws)
+
+    with mock.patch("pytak.classes.takproto", None):
+        with caplog.at_level("WARNING", logger=worker._logger.name):
+            await worker.handle_data(SAMPLE_COT)
+            await worker.handle_data(SAMPLE_COT)
+
+    warnings = [r for r in caplog.records if "takproto" in r.getMessage()]
+    assert len(warnings) == 1
+    assert cot_url in warnings[0].getMessage()
+    assert mock_ws.send_bytes.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_ws_tx_worker_does_not_warn_for_non_takproto_endpoint(caplog):
+    """No warning for a plain WebSocket server that accepts raw CoT XML."""
+    queue = asyncio.Queue()
+    mock_ws = mock.MagicMock()
+    mock_ws.send_bytes = AsyncMock()
+
+    worker = WSTXWorker(queue, {"COT_URL": "ws://example.com/cot"}, mock_ws)
+
+    with mock.patch("pytak.classes.takproto", None):
+        with caplog.at_level("WARNING", logger=worker._logger.name):
+            await worker.handle_data(SAMPLE_COT)
+
+    assert not [r for r in caplog.records if "takproto" in r.getMessage()]
+
+
 # ---------------------------------------------------------------------------
 # WSRXWorker
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #98

Without `takproto` installed, `WSTXWorker.handle_data()` sends raw CoT XML to the `/takproto/1` endpoint; TAK Server discards every frame while the connection stays up and RX keeps working, so the link looks healthy but transmits nothing. Per the issue's suggested fix, a one-time WARNING is now logged when `takproto` is absent and `COT_URL` targets the TAK Protocol path (custom WS servers that accept plain XML are unaffected).

Tests: the new warning test fails on `main` and passes with the fix; `tests/test_ws_workers.py` 14 passed.
