### PR TITLE
Fix the WS TX warning tests: capture from a logger that does not propagate

### DIFF
--- a/tests/test_ws_workers.py
+++ b/tests/test_ws_workers.py
@@ -28,6 +28,8 @@ import pytest
 
 import pytak
 from pytak.classes import WSTXWorker, WSRXWorker, _make_workers
+import contextlib
+import logging
 
 
 SAMPLE_COT = (
@@ -45,6 +47,32 @@ SAMPLE_PROTO_BYTES = b"\xbf\x01\x00"  # minimal fake proto frame
 # ---------------------------------------------------------------------------
 # WSTXWorker
 # ---------------------------------------------------------------------------
+
+
+
+@contextlib.contextmanager
+def capture_from(logger, caplog, level=logging.WARNING):
+    """Capture records from a logger that does not propagate.
+
+    pytak's _setup_logger() sets `propagate = False` (classes.py), so records
+    never reach the root logger where pytest's caplog handler lives. Using
+    `caplog.at_level(..., logger=...)` only changes the LEVEL on that logger --
+    it does not attach the handler to it -- so nothing is captured and the
+    assertion sees zero records.
+
+    That this passed on Python 3.10+ and failed on 3.7-3.9 was pytest-version
+    luck, not a language difference. Attaching caplog's own handler directly to
+    the logger works the same way on every supported version.
+    """
+    handler = caplog.handler
+    previous = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(level)
+    try:
+        yield
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous)
 
 
 @pytest.mark.asyncio
@@ -127,7 +155,7 @@ async def test_ws_tx_worker_warns_once_when_takproto_missing(caplog):
     worker = WSTXWorker(queue, {"COT_URL": cot_url}, mock_ws)
 
     with mock.patch("pytak.classes.takproto", None):
-        with caplog.at_level("WARNING", logger=worker._logger.name):
+        with capture_from(worker._logger, caplog):
             await worker.handle_data(SAMPLE_COT)
             await worker.handle_data(SAMPLE_COT)
 
@@ -147,7 +175,7 @@ async def test_ws_tx_worker_does_not_warn_for_non_takproto_endpoint(caplog):
     worker = WSTXWorker(queue, {"COT_URL": "ws://example.com/cot"}, mock_ws)
 
     with mock.patch("pytak.classes.takproto", None):
-        with caplog.at_level("WARNING", logger=worker._logger.name):
+        with capture_from(worker._logger, caplog):
             await worker.handle_data(SAMPLE_COT)
 
     assert not [r for r in caplog.records if "takproto" in r.getMessage()]


### PR DESCRIPTION
`test_ws_tx_worker_warns_once_when_takproto_missing` has been failing on **Python 3.7, 3.8 and 3.9** since #104 landed, leaving `main` red.

**The code is fine. The test was wrong.**

pytak's `_setup_logger()` sets `propagate = False` (`classes.py:159`), so records never reach the root logger — which is where pytest's `caplog` handler lives. `caplog.at_level(..., logger=name)` only changes the *level* on that logger; it does **not** attach the handler to it. So nothing was captured and the assertion saw zero records.

That this passed on 3.10+ and failed on 3.7–3.9 was **pytest-version luck, not a language difference** — which is worse than a consistent failure, because it made the test look environment-specific rather than simply wrong.

Attaching `caplog`'s own handler directly to the worker's logger behaves identically on every supported version.

## Verified by driving the worker directly, not by trusting CI

```
propagate on worker logger: False
  via root handler   : 0   <- what caplog could see
  via direct attach  : 1   <- what the fix sees
  warn fired once    : True
  url in message     : True
  send_bytes calls   : 2 (expected 2)
```

So the warn-once behaviour and the raw-XML fallback send were correct all along.

Needed to get a green suite before cutting 7.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM