### PR TITLE
StatusWriter: detect two processes writing one status file

### DIFF
--- a/src/pytak/status.py
+++ b/src/pytak/status.py
@@ -31,6 +31,16 @@ logged once, and the file carries ``wall_t`` so a reader can tell "quiet" from
 **It must be bounded.** A gateway runs for months. ``recent`` is a ring buffer
 and the trend is a fixed number of buckets, so the file has a ceiling size no
 matter how much traffic passes through.
+
+**One writer per file.** Each write serialises a WHOLE document, so two
+processes sharing an ``app_name`` do not merge -- the file alternates between
+two disjoint sets of counters, once a second, and every reader sees whichever
+process wrote last. A gateway with several workers should give the writer to
+the single choke point they all feed, not to each worker.
+
+This is easy to get wrong and invisible when you do, so :class:`StatusWriter`
+detects it: if the file it is about to replace was written by a different live
+process, it says so once rather than silently fighting over it.
 """
 
 import json
@@ -125,6 +135,11 @@ class StatusWriter:
         self.write_errors: int = 0
         self._logged_write_error = False
         self._last_write: float = 0.0
+        self._pid = os.getpid()
+        self._last_contention_check: float = 0.0
+        self._logged_contention = False
+        #: Set when another live process is found writing the same file.
+        self.contended_with: Optional[int] = None
 
     # -- collection -------------------------------------------------------
 
@@ -196,10 +211,57 @@ class StatusWriter:
             # data and should say so rather than quietly rendering it as fact.
             "write_errors": self.write_errors,
         }
+        if self.contended_with is not None:
+            # A reader seeing this knows the figures may be from another
+            # process entirely, and should say so rather than render them.
+            doc["contended_with"] = self.contended_with
         doc.update(self._extra)
         return doc
 
     # -- output -----------------------------------------------------------
+
+
+    def _check_sole_writer(self, now: float) -> None:
+        """Warn once if another live process is writing this same file.
+
+        Two writers on one path is not a crash, which is what makes it nasty:
+        the file simply alternates between two disjoint documents and whichever
+        wrote last wins. A UI then shows counters that flicker between two
+        gateways' worth of traffic, and nothing anywhere reports a problem.
+
+        Checked periodically rather than per write, and only until it has
+        something to say, so the common (correct) case costs nothing.
+        """
+        if self._logged_contention or (now - self._last_contention_check) < 30.0:
+            return
+        self._last_contention_check = now
+        try:
+            with open(self.path, "r") as handle:
+                other = json.load(handle)
+        except (OSError, ValueError):
+            return  # absent or mid-replace; nothing to conclude
+
+        pid = other.get("pid")
+        if not isinstance(pid, int) or pid == self._pid:
+            return
+
+        try:
+            os.kill(pid, 0)  # signal 0: liveness test, sends nothing
+        except ProcessLookupError:
+            return  # a previous run of ours; taking the file over is correct
+        except OSError:
+            pass  # exists but not ours to signal -- still a live process
+
+        self.contended_with = pid
+        self._logged_contention = True
+        self._logger.warning(
+            "Status file %s is also being written by PID %s. Each write "
+            "replaces the whole document, so the two will overwrite one "
+            "another and readers will see only whichever wrote last. Give the "
+            "StatusWriter to a single choke point rather than to each worker.",
+            self.path,
+            pid,
+        )
 
     def write(self, now: Optional[float] = None, force: bool = False) -> bool:
         """Write the status file atomically. Returns True if written.
@@ -221,6 +283,8 @@ class StatusWriter:
         now = now if now is not None else time.time()
         if not force and (now - self._last_write) < self.min_write_interval:
             return False
+
+        self._check_sole_writer(now)
 
         try:
             directory = os.path.dirname(self.path)

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -221,3 +221,83 @@ class TestStatusPath:
 
     def test_explicit_root_wins(self, tmp_path):
         assert status_path("x", root=str(tmp_path)).startswith(str(tmp_path))
+
+
+class TestSingleWriter:
+    """Two writers on one path is silent damage, so it must not be silent.
+
+    Each write serialises a whole document, so two processes sharing an
+    app_name do not merge: the file alternates between two disjoint sets of
+    counters and every reader sees whichever wrote last. Three separate
+    gateway integrations hit this independently, which is why the class now
+    detects it rather than only documenting it.
+    """
+
+    def test_warns_once_when_another_live_process_owns_the_file(self, tmp_path, caplog):
+        path = str(tmp_path / "status.json")
+        # A document written by a DIFFERENT but live pid: our own parent works,
+        # and is guaranteed to exist without inventing one.
+        other_pid = os.getppid()
+        with open(path, "w") as handle:
+            json.dump({"app": "other", "pid": other_pid, "wall_t": 1000.0}, handle)
+
+        w = StatusWriter("t", path=path)
+        with caplog.at_level("WARNING"):
+            w.write(now=1000.0, force=True)
+            w._last_contention_check = 0.0  # allow a second check
+            w.write(now=2000.0, force=True)
+
+        warnings = [r for r in caplog.records if "also being written" in r.getMessage()]
+        assert len(warnings) == 1, "must warn, and only once"
+        assert w.contended_with == other_pid
+
+    def test_contention_is_surfaced_in_the_document(self, tmp_path):
+        """So a UI can say the figures may not be this gateway's."""
+        path = str(tmp_path / "status.json")
+        with open(path, "w") as handle:
+            json.dump({"app": "other", "pid": os.getppid(), "wall_t": 1.0}, handle)
+        w = StatusWriter("t", path=path)
+        w.write(now=1000.0, force=True)
+        assert json.loads(open(path).read())["contended_with"] == os.getppid()
+
+    def test_our_own_file_is_not_contention(self, tmp_path, caplog):
+        w = StatusWriter("t", path=str(tmp_path / "status.json"))
+        with caplog.at_level("WARNING"):
+            w.write(now=1000.0, force=True)
+            w._last_contention_check = 0.0
+            w.write(now=2000.0, force=True)
+        assert w.contended_with is None
+        assert not [r for r in caplog.records if "also being written" in r.getMessage()]
+
+    def test_a_dead_pid_is_not_contention(self, tmp_path, caplog):
+        """Our own previous run left this behind; taking it over is correct."""
+        path = str(tmp_path / "status.json")
+        # PID 2^22 is above the default pid_max on Linux, so it cannot be live.
+        with open(path, "w") as handle:
+            json.dump({"app": "old", "pid": 4194304, "wall_t": 1.0}, handle)
+        w = StatusWriter("t", path=path)
+        with caplog.at_level("WARNING"):
+            w.write(now=1000.0, force=True)
+        assert w.contended_with is None
+
+    def test_missing_or_corrupt_file_is_not_contention(self, tmp_path):
+        path = str(tmp_path / "status.json")
+        w = StatusWriter("t", path=path)
+        w.write(now=1000.0, force=True)   # absent
+        with open(path, "w") as handle:
+            handle.write("{not json")
+        w._last_contention_check = 0.0
+        w.write(now=2000.0, force=True)   # corrupt
+        assert w.contended_with is None
+
+    def test_check_does_not_run_on_every_write(self, tmp_path):
+        """The correct case must cost nothing."""
+        w = StatusWriter("t", path=str(tmp_path / "status.json"), min_write_interval=0)
+        calls = []
+        original = w._check_sole_writer
+        w._check_sole_writer = lambda now: (calls.append(now), original(now))[1]
+        for i in range(20):
+            w.write(now=1000.0 + i, force=True)
+        # Called every time, but the expensive read is rate-limited inside.
+        assert len(calls) == 20
+        assert w._last_contention_check == 1000.0


### PR DESCRIPTION
Three separate gateway integrations hit the same hazard independently today — **dronecot** (6 capture workers), **aprscot** (`APRSWorker` + `SensorWorker`) and **sikw00fcot** (three entry points, only two of which `Conflicts=` each other). Each integrator worked it out for themselves, which is a good sign the library should say it rather than leaving it to be rediscovered a fourth time.

## The hazard

Every write serialises a **whole document**, so two processes sharing an `app_name` do not merge. The file alternates between two disjoint sets of counters once a second, and every reader sees whichever wrote last.

A UI shows figures flickering between two gateways' worth of traffic, and nothing anywhere reports a fault. It isn't a crash — which is exactly what makes it nasty.

## What this adds

The rule is now stated in the module docstring: *give the writer to the single choke point the workers feed, not to each worker.*

And because a docstring only helps someone who reads it, `StatusWriter` now **detects** the case. Before replacing the file it checks whether the document there carries a different pid that is still alive; if so it warns **once** and records `contended_with` in its own output, so a UI can report that the figures may not be this gateway's.

```
Status file /run/sikw00fcot/status.json is also being written by PID 1443.
Each write replaces the whole document, so the two will overwrite one another
and readers will see only whichever wrote last. Give the StatusWriter to a
single choke point rather than to each worker.
```

## Deliberately narrow, to avoid crying wolf

- a **dead pid is not contention** — that's our own previous run, and taking the file over is correct after a restart
- our own pid is not contention
- an absent or half-written file concludes nothing
- rate-limited to every 30 s, and stops entirely once it has something to say, so the common correct case costs nothing

Liveness uses `os.kill(pid, 0)`, which sends no signal. A pid that exists but isn't ours to signal still counts as live.

## Tests

6 new (29 in the module, 131 in the suite). All five mutations tried were caught:

| Mutation | Caught |
|---|---|
| never detects contention | ✅ |
| warns per-write instead of once | ✅ |
| treats a dead pid as live | ✅ |
| flags our own pid | ✅ |
| drops the field from the document | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197da7dhvcPoHxYKamrYqyM