### PR TITLE
Silence datagram cleanup after event-loop teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   state is being replaced during an appliance update. PyTAK now tears down the
   affected client cleanly and reconnects with bounded backoff instead of
   terminating the gateway process.
+- Datagram cleanup no longer emits an ignored `Event loop is closed` traceback
+  when an asyncio transport is collected after loop teardown.
 
 ## PyTAK 7.5.0
 

--- a/src/pytak/asyncio_dgram.py
+++ b/src/pytak/asyncio_dgram.py
@@ -69,7 +69,13 @@ class DatagramStream:
         self._drained = drained
 
     def __del__(self):
-        self._transport.close()
+        try:
+            self._transport.close()
+        except RuntimeError:
+            # asyncio transports schedule connection_lost() on close. During
+            # interpreter or asyncio.run() teardown that loop may already be
+            # closed, and a destructor must not emit an ignored traceback.
+            pass
 
     @property
     def exception(self):

--- a/tests/test_multicast_reuse.py
+++ b/tests/test_multicast_reuse.py
@@ -21,6 +21,7 @@ multicast SA feed is that several tools consume it.
 import asyncio
 import socket
 import unittest
+from unittest import mock
 from urllib.parse import urlparse
 
 import pytak
@@ -31,11 +32,25 @@ PORT = 26969
 
 
 class MulticastReuseTestCase(unittest.TestCase):
+    def test_destructor_tolerates_closed_event_loop(self):
+        """Best-effort cleanup must not raise after asyncio.run() teardown."""
+        transport = mock.Mock()
+        transport.close.side_effect = RuntimeError("Event loop is closed")
+        stream = pytak.asyncio_dgram.DatagramStream(
+            transport, mock.sentinel.recvq, mock.sentinel.excq, mock.sentinel.drained
+        )
+
+        stream.__del__()
+
+        transport.close.assert_called_once_with()
+        transport.close.side_effect = None
+
     def test_second_subscriber_can_bind(self):
         """A second reader on the same group/port must not raise EADDRINUSE."""
 
         async def go():
             first = await pytak.create_udp_client(urlparse(f"udp+ro://{GROUP}:{PORT}"))
+            second = (None, None)
             try:
                 # This is the call that used to raise OSError(98).
                 second = await pytak.create_udp_client(urlparse(f"udp+ro://{GROUP}:{PORT}"))
@@ -43,7 +58,7 @@ class MulticastReuseTestCase(unittest.TestCase):
                     pass
                 self.assertIsNotNone(second)
             finally:
-                for pair in (first,):
+                for pair in (second, first):
                     for sock in pair:
                         if sock is not None and hasattr(sock, "close"):
                             try:
@@ -70,11 +85,17 @@ class MulticastReuseTestCase(unittest.TestCase):
         holder.bind(("", PORT + 1))
 
         async def go():
-            return await pytak.create_udp_client(urlparse(f"udp+ro://{GROUP}:{PORT + 1}"))
+            reader, _writer = await pytak.create_udp_client(
+                urlparse(f"udp+ro://{GROUP}:{PORT + 1}")
+            )
+            try:
+                return reader is not None
+            finally:
+                if reader is not None:
+                    reader.close()
 
         try:
-            reader, _writer = asyncio.run(go())
-            self.assertIsNotNone(reader)
+            self.assertTrue(asyncio.run(go()))
         finally:
             holder.close()
 


### PR DESCRIPTION
## Summary

- make DatagramStream finalizer best-effort when asyncio loop teardown already happened
- close multicast regression transports inside their owning event loop
- add a direct destructor regression
- document the cleanup fix in the pending 7.5.1 notes

## Validation

- 240 passed on Python 3.13
- no PytestUnraisableExceptionWarning from DatagramStream
- git diff --check